### PR TITLE
Critical: Fix for keyword conflict in addon helper

### DIFF
--- a/libraries/Escher/Controller/Action/Helper/Addons.php
+++ b/libraries/Escher/Controller/Action/Helper/Addons.php
@@ -77,7 +77,7 @@ class Escher_Controller_Action_Helper_Addons extends Zend_Controller_Action_Help
      *
      * @return string
      */
-    public function list()
+    public function addonList()
     {
         // Build the list of addons only once.
         if (!$this->isEmpty()) {

--- a/libraries/Escher/Form/Upload.php
+++ b/libraries/Escher/Form/Upload.php
@@ -27,7 +27,7 @@ class Escher_Form_Upload extends Omeka_Form
             'theme' => __('Themes'),
         );
 
-        $list = $addons->list();
+        $list = $addons->addonList();
         foreach($list as $addonType => $addonsForType) {
             if (empty($addonsForType)) {
                 continue;


### PR DESCRIPTION
This pull request resolves the following error that appears when opening the Escher admin menu:

Parse error: syntax error, unexpected 'list' (T_LIST), expecting identifier (T_STRING) in /var/www/html/omeka-dev/plugins/Escher/libraries/Escher/Controller/Action/Helper/Addons.php on line 80