### PR TITLE
Fixed array declaration for PHP 5.3 compatibility

### DIFF
--- a/controllers/IndexController.php
+++ b/controllers/IndexController.php
@@ -312,11 +312,11 @@ class Escher_IndexController extends Omeka_Controller_AbstractActionController
         // fails with a "Permission Denied" error because the current working
         // directory cannot be set properly via exec().  Note that exec() works
         // fine when executing in the web environment but fails in CLI.
-        $descriptorSpec = [
+        $descriptorSpec = array(
             0 => array('pipe', 'r'), //STDIN
             1 => array('pipe', 'w'), //STDOUT
             2 => array('pipe', 'w'), //STDERR
-        ];
+        );
         if ($proc = proc_open($command, $descriptorSpec, $pipes, getcwd())) {
             $output = stream_get_contents($pipes[1]);
             $errors = stream_get_contents($pipes[2]);


### PR DESCRIPTION
Declaration of $descriptorSpec in line 315 was causing a fatal 500 error on system with PHP 5.3 installed.

> Parse error: syntax error, unexpected '[' in /var/www/omeka/plugins/Escher/controllers/IndexController.php on line 315

Since current Omeka lists support for 5.3.2 or greater, I changed this to the pre-5.4 array declaration syntax.